### PR TITLE
[31기 남용현] ADD: 공통 Aside 메뉴 구현

### DIFF
--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -1,7 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import MenuList from './MenuList/MenuList';
+import './Aside.scss';
 
 const Aside = () => {
-  return <div>Aside</div>;
+  const [isOpenSubMenu, setIsOpenSubMenu] = useState(false);
+  const navigate = useNavigate();
+  const onRefresh = () => {
+    navigate('/');
+    setIsOpenSubMenu(false);
+  };
+
+  return (
+    <section className="aside">
+      <div className="asideTitle" onClick={onRefresh}>
+        <img className="titleLogo" alt="logo" src="/images/logo.png" />
+        <h3 className="titleName">프 룯 츠</h3>
+      </div>
+      <MenuList
+        setIsOpenSubMenu={setIsOpenSubMenu}
+        isOpenSubMenu={isOpenSubMenu}
+      />
+    </section>
+  );
 };
 
 export default Aside;

--- a/src/components/Aside/Aside.js
+++ b/src/components/Aside/Aside.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import MenuList from './MenuList/MenuList';
 import './Aside.scss';
 

--- a/src/components/Aside/Aside.scss
+++ b/src/components/Aside/Aside.scss
@@ -1,0 +1,29 @@
+@import '../../styles/variables.scss';
+@font-face {
+  font-family: 'SEBANG_Gothic_Bold';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2104@1.0/SEBANG_Gothic_Bold.woff')
+    format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.aside {
+  position: fixed;
+  left: 50px;
+  top: 50px;
+
+  .asideTitle {
+    cursor: pointer;
+
+    .titleLogo {
+      width: 105px;
+    }
+
+    .titleName {
+      font-size: 23px;
+      font-family: 'SEBANG_Gothic_Bold';
+      letter-spacing: 5px;
+      color: $color-title;
+    }
+  }
+}

--- a/src/components/Aside/MenuList/ListItem.js
+++ b/src/components/Aside/MenuList/ListItem.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './ListItem.scss';
+
+const ListItem = ({
+  idx,
+  activeIndex,
+  setActiveIndex,
+  title,
+  list,
+  setIsOpenSubMenu,
+  isOpenSubMenu,
+}) => {
+  const [subActiveIdx, setSubActiveIdx] = useState();
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    setIsOpenSubMenu(true);
+    setActiveIndex(idx);
+    setSubActiveIdx(null);
+    !list && navigate(`/${title.replace(' ', '').toLowerCase()}`);
+  };
+
+  const handleLink = (e, idx) => {
+    setSubActiveIdx(idx);
+    navigate({
+      pathname: `/product/${e.target.innerText.replace(' ', '').toLowerCase()}`,
+      state: {
+        title: idx,
+      },
+    });
+  };
+
+  return (
+    <li className="listLi">
+      <div className="listTitle" onClick={handleClick}>
+        {title}
+      </div>
+      <div className={idx === activeIndex ? '' : 'closed'}>
+        {isOpenSubMenu &&
+          list?.map((subList, index) => {
+            return (
+              <div
+                key={index}
+                onClick={subList => handleLink(subList, index)}
+                className="listSub"
+              >
+                <div
+                  className={
+                    subActiveIdx === index
+                      ? ['listDot', 'listActive'].join(' ')
+                      : 'listDot'
+                  }
+                />
+                {subList}
+              </div>
+            );
+          })}
+      </div>
+    </li>
+  );
+};
+
+export default ListItem;

--- a/src/components/Aside/MenuList/ListItem.scss
+++ b/src/components/Aside/MenuList/ListItem.scss
@@ -1,0 +1,40 @@
+@import '../../../styles/variables.scss';
+
+.listLi {
+  .listTitle {
+    cursor: pointer;
+    padding-bottom: 5px;
+    &:hover {
+      font-weight: 700;
+    }
+    margin-top: 20px;
+  }
+
+  .closed {
+    display: none;
+  }
+}
+
+.listSub {
+  font-size: 11px;
+  cursor: pointer;
+  padding-top: 10px;
+  // margin-top: 10px;
+  &:hover {
+    font-weight: 500;
+  }
+  &:nth-child(1) {
+    border-top: 1px solid $color-navy;
+  }
+
+  .listDot {
+    display: inline-block;
+    margin-right: 5px;
+    width: 8px;
+    height: 8px;
+    border: 1px solid $color-navy;
+  }
+  .listActive {
+    background-color: $color-navy;
+  }
+}

--- a/src/components/Aside/MenuList/MenuList.js
+++ b/src/components/Aside/MenuList/MenuList.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+import ListItem from './ListItem';
+import './MenuList';
+import './MenuList.scss';
+
+const AsideMenu = ({ setIsOpenSubMenu, isOpenSubMenu }) => {
+  const [activeIndex, setActiveIndex] = useState();
+
+  return (
+    <ul className="menuList">
+      {MENU_LIST.map((menuList, idx) => {
+        return (
+          <ListItem
+            key={idx}
+            idx={idx}
+            {...menuList}
+            activeIndex={activeIndex}
+            setActiveIndex={setActiveIndex}
+            setIsOpenSubMenu={setIsOpenSubMenu}
+            isOpenSubMenu={isOpenSubMenu}
+          />
+        );
+      })}
+    </ul>
+  );
+};
+
+export default AsideMenu;
+
+const MENU_LIST = [
+  { title: 'ABOUT', list: ['DIRECT TRADE', 'TEAM MEMBER'] },
+  { title: 'SHOP', list: ['FRUIT', 'BEVERAGE', 'GOODS', 'GIFTS'] },
+  { title: 'FRUITZ CLUB' },
+  { title: 'WHOLESALE', list: ['ABOUT FRUITZ', 'NOTICE / Q&A'] },
+  { title: 'CONTACT' },
+];

--- a/src/components/Aside/MenuList/MenuList.scss
+++ b/src/components/Aside/MenuList/MenuList.scss
@@ -1,0 +1,10 @@
+@import '../../../styles/variables.scss';
+
+
+.menuList {
+  margin-top: 40px;
+  width: 160px;
+  font-family: $font-main;
+  font-size: 13px;
+  color: $color-navy;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 공통 Aside 메뉴 UI 구현
- 트리구조 UI
- 메뉴에 맞는 네비게이트 이동

<br />

## :: 구현 사항 설명 
1. 프릳츠커피와 동일한 트리구조 UI 메뉴
2. 메뉴를 클릭시 각 메뉴에 맞는 페이지로 라우팅

<br />

## :: 성장 포인트 
- 리액트에서의 트리구조 메뉴를 만들때 일일이 메뉴명을 써주지않고 배열을 만들어서 트리구조의 메뉴를 만들어 보았는데
이런식으로 하면 간단하고 깔끔하게 만들수 있어서 좋았습니다.

<br />

## :: 기타 질문 및 특이 사항

