### PR TITLE
[31기 남용현] ADD: 공통 header 메뉴 구현

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,65 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './Header.scss';
+const Header = ({ isLogin, setIsLogin }) => {
+  const navigate = useNavigate();
 
-const Header = () => {
-  return <div>Header</div>;
+  const goToPage = (event, idx) => {
+    if (idx === 6) {
+      alert('다국어는 지금 지원하지 않습니다.');
+      return;
+    }
+    if (isLogin) {
+      if (idx === 0) {
+        localStorage.removeItem('fruitz_user');
+        setIsLogin(false);
+        navigate('member/login');
+        return;
+      }
+    }
+    navigate({
+      pathname:
+        idx === 0
+          ? `member/${event.target.innerText.replace(' ', '').toLowerCase()}`
+          : `${event.target.innerText.replace(' ', '').toLowerCase()}`,
+    });
+  };
+
+  const navList = [
+    isLogin ? 'LOGOUT' : 'LOGIN',
+    '',
+    'MY PAGE',
+    '',
+    'CART',
+    '',
+    'ENG VER(GLOBAL SHIPPING)',
+  ];
+
+  return (
+    <section className="header">
+      <nav className="nav">
+        <div className="navTitle">
+          <h3 className="title">FRUITZ COMPANY</h3>
+          <p className="subTitle">FRESH & NUTRITION</p>
+        </div>
+        <ul className="navMenu">
+          {navList.map((listName, idx) => {
+            return (
+              <li
+                key={idx}
+                className="navList"
+                onClick={event => {
+                  goToPage(event, idx);
+                }}
+              >
+                {listName}
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </section>
+  );
 };
 
 export default Header;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,51 @@
+@import '../../styles/variables.scss';
+
+.header {
+  .nav {
+    position: fixed;
+    top: 0;
+    right: 0;
+    padding: 30px;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    color: $color-navy;
+    width: 100%;
+    background-color: #f8f8ed85;
+  }
+
+  .navTitle {
+    margin-right: 95px;
+
+    .title {
+      font-weight: bolder;
+      font-size: 19px;
+    }
+
+    .subTitle {
+      padding-top: 3px;
+      font-family: $font-main;
+      font-size: 11px;
+    }
+  }
+
+  .navMenu {
+    display: flex;
+    align-items: center;
+    margin-right: 20px;
+    font-family: $font-main;
+    font-size: 12px;
+
+    .navList {
+      &:nth-child(even) {
+        width: 1px;
+        height: 8px;
+        background-color: $color-navy;
+      }
+      &:not(:nth-child(even)) {
+        margin: 0 10px;
+        cursor: pointer;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 공통 헤더 메뉴 UI 구현

<br />

## :: 구현 사항 설명 
1. 공통 헤더 메뉴 UI 구현
  - 실제 사이트와 동일한 메뉴 구성

2. 메뉴 클릭시 해당 페이지 이동

3. 로그인 되었을시 토큰 보유 유무로 LOGIN -> LOGOUT 으로 변경
<br />

## :: 성장 포인트
- 해당 메뉴도 따로 배열을 만들어 리스트로 UI를 구성하였으며 로그인을 했을시 로그인이 로그아웃으로 바뀌는 로직이
처음에는 난해하였으나 삼항연산자, 스테이트 등으로 인하 구현할수 있게되어 뿌듯했습니다.
- 실제 페이지는 단순 토큰 보유만으로 로그인유지가 아닐것이고 보안 관련해서 더 어려울것 같아서 공부를 더 해야겠습니다.

<br />

## :: 기타 질문 및 특이 사항

